### PR TITLE
Restricting Zoom

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "editor.formatOnSave": true,
-  "prettier.configPath": "./prettierrc.json"
-}

--- a/src/vis/MeasurementMap.tsx
+++ b/src/vis/MeasurementMap.tsx
@@ -22,9 +22,8 @@ const ATTRIBUTION =
   'Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, ' +
   'under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.';
 
-const URL = `https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}${
-  devicePixelRatio > 1 ? '@2x' : ''
-}.png`;
+const URL = `https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}${devicePixelRatio > 1 ? '@2x' : ''
+  }.png`;
 
 const BIN_SIZE_SHIFT = 0;
 const DEFAULT_ZOOM = 10;
@@ -115,8 +114,8 @@ const MeasurementMap = ({
 
       L.tileLayer(URL, {
         attribution: ATTRIBUTION,
-        maxZoom: 25,
-        minZoom: 8,
+        maxZoom: 16,
+        minZoom: 10,
         opacity: 0.7,
         zIndex: 1,
       }).addTo(_map);
@@ -144,11 +143,11 @@ const MeasurementMap = ({
       }
       const _siteSummary = await fetchToJson(
         API_URL +
-          '/api/sitesSummary?' +
-          new URLSearchParams([
-            ['timeFrom', timeFrom.toISOString()],
-            ['timeTo', timeTo.toISOString()],
-          ]),
+        '/api/sitesSummary?' +
+        new URLSearchParams([
+          ['timeFrom', timeFrom.toISOString()],
+          ['timeTo', timeTo.toISOString()],
+        ]),
       );
       setSiteSummary(_siteSummary);
     })();
@@ -276,19 +275,19 @@ const MeasurementMap = ({
       setBins(
         await fetchToJson(
           API_URL +
-            '/api/data?' +
-            new URLSearchParams([
-              ['width', bounds.width + ''],
-              ['height', bounds.height + ''],
-              ['left', bounds.left + ''],
-              ['top', bounds.top + ''],
-              ['binSizeShift', BIN_SIZE_SHIFT + ''],
-              ['zoom', DEFAULT_ZOOM + ''],
-              ['selectedSites', selectedSites.map(ss => ss.label).join(',')],
-              ['mapType', mapType],
-              ['timeFrom', timeFrom.toISOString()],
-              ['timeTo', timeTo.toISOString()],
-            ]),
+          '/api/data?' +
+          new URLSearchParams([
+            ['width', bounds.width + ''],
+            ['height', bounds.height + ''],
+            ['left', bounds.left + ''],
+            ['top', bounds.top + ''],
+            ['binSizeShift', BIN_SIZE_SHIFT + ''],
+            ['zoom', DEFAULT_ZOOM + ''],
+            ['selectedSites', selectedSites.map(ss => ss.label).join(',')],
+            ['mapType', mapType],
+            ['timeFrom', timeFrom.toISOString()],
+            ['timeTo', timeTo.toISOString()],
+          ]),
         ),
       );
     })();

--- a/src/vis/MeasurementMap.tsx
+++ b/src/vis/MeasurementMap.tsx
@@ -22,8 +22,9 @@ const ATTRIBUTION =
   'Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, ' +
   'under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.';
 
-const URL = `https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}${devicePixelRatio > 1 ? '@2x' : ''
-  }.png`;
+const URL = `https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}${
+  devicePixelRatio > 1 ? '@2x' : ''
+}.png`;
 
 const BIN_SIZE_SHIFT = 0;
 const DEFAULT_ZOOM = 10;
@@ -143,11 +144,11 @@ const MeasurementMap = ({
       }
       const _siteSummary = await fetchToJson(
         API_URL +
-        '/api/sitesSummary?' +
-        new URLSearchParams([
-          ['timeFrom', timeFrom.toISOString()],
-          ['timeTo', timeTo.toISOString()],
-        ]),
+          '/api/sitesSummary?' +
+          new URLSearchParams([
+            ['timeFrom', timeFrom.toISOString()],
+            ['timeTo', timeTo.toISOString()],
+          ]),
       );
       setSiteSummary(_siteSummary);
     })();
@@ -275,19 +276,19 @@ const MeasurementMap = ({
       setBins(
         await fetchToJson(
           API_URL +
-          '/api/data?' +
-          new URLSearchParams([
-            ['width', bounds.width + ''],
-            ['height', bounds.height + ''],
-            ['left', bounds.left + ''],
-            ['top', bounds.top + ''],
-            ['binSizeShift', BIN_SIZE_SHIFT + ''],
-            ['zoom', DEFAULT_ZOOM + ''],
-            ['selectedSites', selectedSites.map(ss => ss.label).join(',')],
-            ['mapType', mapType],
-            ['timeFrom', timeFrom.toISOString()],
-            ['timeTo', timeTo.toISOString()],
-          ]),
+            '/api/data?' +
+            new URLSearchParams([
+              ['width', bounds.width + ''],
+              ['height', bounds.height + ''],
+              ['left', bounds.left + ''],
+              ['top', bounds.top + ''],
+              ['binSizeShift', BIN_SIZE_SHIFT + ''],
+              ['zoom', DEFAULT_ZOOM + ''],
+              ['selectedSites', selectedSites.map(ss => ss.label).join(',')],
+              ['mapType', mapType],
+              ['timeFrom', timeFrom.toISOString()],
+              ['timeTo', timeTo.toISOString()],
+            ]),
         ),
       );
     })();


### PR DESCRIPTION
# What 
Restricts zoom of the map for zooming in too far and out too far.

# Why
The map turns completely grey when it is zoomed in too far, this ensures it is impossible to zoom in that far. The map zooms in too far when a user searches for an address.
Since the coverage is restricted to Seattle, the zoom should be restricted so the user cannot zoom out past the Seattle area.

# How
Increases the minimum zoom and decreases the maximum zoom on MeasurementMap.tsx. 

# Screenshots

**When a user searches now:** 

![image](https://user-images.githubusercontent.com/82297766/212006035-e154f01f-13db-4594-900a-2774a68232f5.png)

**A search with the changed code:**

![image](https://user-images.githubusercontent.com/82297766/212006581-8f70f477-202e-4820-9985-ef92b5ef54d9.png)

